### PR TITLE
navigate back 을 관리해주는  hook 작성

### DIFF
--- a/app/hooks/useFilterNavigation.ts
+++ b/app/hooks/useFilterNavigation.ts
@@ -1,0 +1,46 @@
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useCallback } from 'react'
+
+interface UseFilterNavigationOptions {
+  replace?: boolean
+}
+
+export const useFilterNavigation = (
+  options: UseFilterNavigationOptions = {}
+) => {
+  const { replace = true } = options
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  const updateFilter = useCallback(
+    (key: string, value?: string) => {
+      const params = new URLSearchParams(searchParams.toString())
+
+      if (!value) {
+        params.delete(key)
+      } else {
+        params.set(key, value)
+      }
+
+      const queryString = params.toString()
+      const newPath = queryString ? `?${queryString}` : ''
+
+      if (replace) {
+        router.replace(newPath)
+      } else {
+        router.push(newPath)
+      }
+    },
+    [router, searchParams, replace]
+  )
+
+  const resetFilters = useCallback(() => {
+    router.replace('')
+  }, [router])
+
+  return {
+    updateFilter,
+    resetFilters,
+    currentFilters: searchParams,
+  }
+}


### PR DESCRIPTION
## 종류

- [ ] ✍️ 새 글 발행
- [x] 🛠️ 기술 개발å
- [ ] 🎨 디자인/UI 개선
- [ ] 🐛 버그 수정
- [ ] 📝 문서 수정

## 작업 내용
<!-- 구체적으로 어떤 작업을 했는지 설명해주세요 -->
Next.js 앱에서 필터링 상태 관리를 위한 useFilterNavigation 훅을 구현.
- 목적
   - URL 기반 필터링 상태 관리
   - 브라우저 히스토리 최적화

- 주요 기능
   - updateFilter: 단일 필터 값 업데이트
   - resetFilters: 모든 필터 초기화
   - currentFilters: 현재 필터 상태 접근
   
-뒤로가기 전략
`typescriptCopyconst { replace = true } = options`
   - 기본적으로 router.replace를 사용하여 히스토리 스택이 불필요하게 쌓이는 것을 방지
   - 필터 변경 시마다 새로운 히스토리 엔트리 생성을 막음
   - 옵션을 통해 필요한 경우 router.push로 전환 가능

## 스크린샷
<!-- 필요한 경우 변경사항을 시각적으로 보여주세요 -->

## 메모
<!-- 나중에 참고할 내용이나 특이사항이 있다면 작성해주세요 -->
- 구현 특이사항
   - URLSearchParams를 사용하여 안전한 쿼리스트링 조작
   - useCallback으로 불필요한 리렌더링 방지
   - pathname 없이 쿼리스트링만 사용하여 깔끔한 URL 유지

- 히스토리 관리: 필터링은 페이지의 상태 변화일 뿐, 새로운 페이지 탐색이 아니므로 replace 사용
- 사용자 경험: 뒤로가기 시 불필요한 중간 상태 제거