### PR TITLE
Fix/nav bug

### DIFF
--- a/app/(blog)/components/BlogPost.tsx
+++ b/app/(blog)/components/BlogPost.tsx
@@ -1,4 +1,4 @@
-import { Card } from './card'
+import { Card } from '../../components/card'
 
 import { getBlogPosts, sortByDate } from '@/(blog)/utils'
 

--- a/app/(blog)/page.tsx
+++ b/app/(blog)/page.tsx
@@ -1,6 +1,6 @@
 import BlogCategories from './components/Categories'
 
-import { BlogPosts } from '@/components/posts'
+import { BlogPosts } from '@/(blog)/components/BlogPost'
 
 export const metadata = {
   title: 'Blog',

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,4 +1,4 @@
-import { BlogPosts } from '@/components/posts'
+import { BlogPosts } from '@/(blog)/components/BlogPost'
 
 export default function Page() {
   return (

--- a/app/components/nav.tsx
+++ b/app/components/nav.tsx
@@ -2,9 +2,9 @@
 
 import { SunMedium, MoonStar } from 'lucide-react'
 import Link from 'next/link'
-import { usePathname } from 'next/navigation'
 
 import { Switch } from '@/components/ui/switch'
+import { useNavigation } from '@/hooks/useNavigation'
 import useSetThemeMode from '@/hooks/useSetThemeMode'
 
 const navItems = {
@@ -18,7 +18,7 @@ const navItems = {
 
 export function Navbar() {
   const { mode, toggleMode } = useSetThemeMode()
-  const pathname = usePathname()
+  const { isNavActive } = useNavigation()
 
   return (
     <aside className="mb-2 tracking-tight">
@@ -26,7 +26,7 @@ export function Navbar() {
         <nav className="flex justify-between items-center" id="nav">
           <div className="flex space-x-0">
             {Object.entries(navItems).map(([path, { name }]) => {
-              const isActive = pathname === path
+              const isActive = isNavActive(path)
 
               return (
                 <Link

--- a/app/hooks/useNavigation.ts
+++ b/app/hooks/useNavigation.ts
@@ -1,0 +1,19 @@
+import { usePathname } from 'next/navigation'
+
+export const useNavigation = () => {
+  const pathname = usePathname()
+
+  const isNavActive = (path: string) => {
+    if (path === '/about') {
+      return pathname === '/about'
+    }
+
+    if (path === '/') {
+      return pathname === '/' || pathname !== '/about'
+    }
+
+    return pathname === path
+  }
+
+  return { isNavActive }
+}


### PR DESCRIPTION
## 종류

- [ ] ✍️ 새 글 발행
- [ ] 🛠️ 기술 개발å
- [ ] 🎨 디자인/UI 개선
- [x] 🐛 버그 수정
- [ ] 📝 문서 수정

## 작업 내용
<!-- 구체적으로 어떤 작업을 했는지 설명해주세요 -->

```typescript
const isNavActive = (path: string) => {
  if (path === '/about') {
    return pathname === '/about'
  }
  
  if (path === '/') {
    return pathname === '/' || pathname !== '/about'
  }
  
  return pathname === path
}
```


1. About 페이지 처리
   - `/about` 경로인 경우만 About 메뉴가 활성화
   - 정확히 일치할 때만 활성화

2. 블로그(홈) 처리
   - `/about`을 제외한 모든 경로에서 Blog 메뉴가 활성화
   - 예를 들어 `/post-1`, `/about-react` 등 모든 경로가 포함
   - `/about`만 유일하게 제외됩니다

의도한바
- 블로그 글의 URL 패턴이 바뀌어도 잘 동작
- 불필요한 복잡성을 피하기. 단일 책임(navigation에만 집중)
-  커스텀 훅으로 분리함으로써 코드의 재사용성 향상

## 스크린샷
<!-- 필요한 경우 변경사항을 시각적으로 보여주세요 -->

## 메모
<!-- 나중에 참고할 내용이나 특이사항이 있다면 작성해주세요 -->