### PR TITLE
fcp 속도 향상

### DIFF
--- a/app/(blog)/components/BlogPosts.tsx
+++ b/app/(blog)/components/BlogPosts.tsx
@@ -1,9 +1,9 @@
 import { FilteredBlogPosts } from './FilteredBlogPosts'
 
-import { getBlogPosts } from '@/(blog)/utils/mdx'
+import { getBlogPostsMetadata } from '@/(blog)/utils/mdx'
 
 export async function BlogPosts() {
-  const posts = await getBlogPosts()
+  const posts = await getBlogPostsMetadata()
 
   return <FilteredBlogPosts posts={posts} />
 }

--- a/app/(blog)/components/FilteredBlogPosts.tsx
+++ b/app/(blog)/components/FilteredBlogPosts.tsx
@@ -8,10 +8,10 @@ import { sortByDate } from '../utils/date'
 import { Card } from '@/components/card'
 import { useFilterNavigation } from '@/hooks/useFilterNavigation'
 import { getCategoryLabel } from '@/lib/blog'
-import { BLOG_CATEGORIES, BlogPost } from '@/types/blog'
+import { BLOG_CATEGORIES, BlogPostMetadata } from '@/types/blog'
 
 interface Props {
-  posts: BlogPost[]
+  posts: BlogPostMetadata[]
 }
 
 export function FilteredBlogPosts({ posts }: Props) {

--- a/app/(blog)/utils/mdx.ts
+++ b/app/(blog)/utils/mdx.ts
@@ -3,7 +3,12 @@
 import fs from 'fs'
 import path from 'path'
 
-import { BLOG_CATEGORIES, BlogCategory, BlogMetadata } from '@/types/blog'
+import {
+  BLOG_CATEGORIES,
+  BlogCategory,
+  BlogMetadata,
+  BlogPostMetadata,
+} from '@/types/blog'
 
 const parseFrontmatter = async (fileContent: string) => {
   const frontmatterRegex = /---\s*([\s\S]*?)\s*---/
@@ -85,4 +90,25 @@ const getMDXData = async (dir: string) => {
 
 export async function getBlogPosts() {
   return getMDXData(path.join(process.cwd(), 'app', '(blog)', 'posts'))
+}
+
+export async function getBlogPostsMetadata(): Promise<BlogPostMetadata[]> {
+  const mdxFiles = await getMDXFiles(
+    path.join(process.cwd(), 'app', '(blog)', 'posts')
+  )
+
+  return Promise.all(
+    mdxFiles.map(async (file) => {
+      const filePath = path.join(process.cwd(), 'app', '(blog)', 'posts', file)
+      const rawContent = fs.readFileSync(filePath, 'utf-8')
+
+      const { metadata } = await parseFrontmatter(rawContent)
+      const slug = path.basename(file, path.extname(file))
+
+      return {
+        metadata,
+        slug,
+      }
+    })
+  )
 }

--- a/app/types/blog.ts
+++ b/app/types/blog.ts
@@ -33,3 +33,5 @@ export interface BlogPost {
   slug: string
   content: string
 }
+
+export type BlogPostMetadata = Omit<BlogPost, 'content'>


### PR DESCRIPTION
## 종류

- [ ] ✍️ 새 글 발행
- [x] 🛠️ 기술 개발å
- [ ] 🎨 디자인/UI 개선
- [ ] 🐛 버그 수정
- [ ] 📝 문서 수정

## 작업 내용
<!-- 구체적으로 어떤 작업을 했는지 설명해주세요 -->
- 메타데이터만 불러오는 방식으로 변경 ->FCP(First Contentful Paint) 속도 향상
- as-is ) 모든 블로그 글의 전체 내용(content)을 초기 페이지 로드 시 함께 가져옴
   - 데이터 크기 증가: 모든 블로그 포스트의 전체 내용이 포함되어 초기 페이로드가 매우 커짐
   - JS 번들 크기 증가: 모든 콘텐츠가 __NEXT_DATA__ script 태그에 포함되어 JS 번들 크기가 증가
   - 파싱 시간 증가: 브라우저가 처리해야 할 데이터가 많아 파싱 시간이 길어짐
- to-be) 메타데이터만 로드하도록 최적화
   - 데이터 크기 감소: 제목, 날짜, 요약 등 필요한 정보만 가져와 초기 페이로드가 크게 줄어듬
   - 빠른 렌더링: 적은 데이터로 인해 페이지 렌더링이 빨라짐
   - FCP 개선: 첫 콘텐츠가 화면에 표시되는 시간이 단축

## 스크린샷
<!-- 필요한 경우 변경사항을 시각적으로 보여주세요 -->
as-is
1s -> 0.8s 으로 감소

## 메모
<!-- 나중에 참고할 내용이나 특이사항이 있다면 작성해주세요 -->